### PR TITLE
Added unsaved changes prompt via enhanced zlux-popup-window

### DIFF
--- a/webClient/src/app/workflow-app/workflow-app.component.html
+++ b/webClient/src/app/workflow-app/workflow-app.component.html
@@ -41,6 +41,54 @@
 </workflow-create>
 <zosmf-login #zosmflogin on-loggedIn="login()"></zosmf-login>
 <workflow-notification></workflow-notification>
+<zlux-popup-window
+      i18n-header="dialog header|Header for close dialog@@close-dialog-header"
+      header="Unsaved Configuration Changes"
+      (onCloseWindow)="cancelCloseDialog()"
+      [dark]="true"
+      [currentStyle]="{ 'width': '40em', 'height': '12em' , 'background-color': '#F6F6F6', 'font-size': 'large', 'padding': '3px'}"
+      *ngIf="isOnCloseDialogVisible">
+      <div class="content-close">Do you want to save your Configuration changes?<br>If you click “Exit”, your current changes will be discarded and the program will close.</div>
+      <zlux-popup-window-button-area>
+        <zlux-button (click)="saveChanges(); exit();"
+          i18n-label="label|Label for Save Changes and Exit button@@save-changes-and-exit-label"
+          label="Save & Exit"
+          callToAction="true">
+        </zlux-button>
+        <zlux-button (click)="exit()"
+          i18n-label="label|Label for Exit button@@exit-button-label"
+          label="Exit">
+        </zlux-button>
+        <zlux-button (click)="cancelCloseDialog()"
+          i18n-label="label|Label of Cancel Dialog button@@cancel-dialog-button-label"
+          label="Cancel">
+        </zlux-button>
+      </zlux-popup-window-button-area>
+  </zlux-popup-window>
+  <zlux-popup-window
+      i18n-header="dialog header|Header for unsaved changes dialog@@unsaved-changes-dialog-header"
+      header="Unsaved Configuration Changes"
+      (onCloseWindow)="cancelUnsavedChangesDialog()"
+      [dark]="true"
+      [currentStyle]="{ 'width': '40em', 'height': '12em' , 'background-color': '#F6F6F6', 'font-size': 'large', 'padding': '3px'}"
+      *ngIf="isUnsavedChangesDialogVisible">
+      <div class="content-unsaved-changes">Do you want to save your Configuration changes?<br>If you click “Don’t Save”, your current changes will be discarded.</div>
+      <zlux-popup-window-button-area>
+        <zlux-button (click)="saveChanges()"
+          i18n-label="label|Label of Save Changes button@@save-changes-button-label"
+          label="Save">
+        </zlux-button>
+        <zlux-button (click)="abandonChanges()"
+          i18n-label="label|Label for Abandon Changes button@@abandon-changes-label"
+          label="Don't Save"
+          callToAction="true">
+        </zlux-button>
+        <zlux-button (click)="cancelUnsavedChangesDialog()"
+          i18n-label="label|Label for Cancel button@@cancel-button-label"
+          label="Cancel">
+        </zlux-button>
+      </zlux-popup-window-button-area>
+  </zlux-popup-window>
 <zlux-veil [isEnabled]="globalVeilService.isEnabled()" [enableSpinner]="true"></zlux-veil>
 <workflow-confirmation></workflow-confirmation>
 <!--

--- a/webClient/src/app/workflow-app/workflow-app.component.ts
+++ b/webClient/src/app/workflow-app/workflow-app.component.ts
@@ -85,6 +85,11 @@ export class WorkflowAppComponent implements AfterContentInit {
   nextWorkflowStepIsReady: boolean = false;
   viewCreateWorkflow: boolean = false;
   activeMenuItem: WorkflowView = 'My Tasks';
+  requestedMenuItem: WorkflowView = this.activeMenuItem;
+  resolveClose: () => void;
+  rejectClose: () => void;
+  isOnCloseDialogVisible = false;
+  isUnsavedChangesDialogVisible = false;
 
   constructor(
     @Inject(Angular2InjectionTokens.LAUNCH_METADATA) private launchMetadata: WorkflowAppLaunchMetadata,
@@ -118,9 +123,50 @@ export class WorkflowAppComponent implements AfterContentInit {
   }
 
   ngAfterContentInit(): void {
+    this.windowActions.registerCloseHandler(() => this.onClose())
     if (!this.configured) {
       this.showConfiguration();
     }
+  }
+
+  onClose(): Promise<void> {
+    if (this.zosmfServerConfigComponent.unsavedChanges()) {
+      this.globalVeilService.showVeil();
+      this.isOnCloseDialogVisible = true;
+      return new Promise((resolve, reject) => {
+        this.resolveClose = resolve;
+        this.rejectClose = reject;
+      });
+    } else {
+      return Promise.resolve();
+    }
+  }
+
+  saveChanges(): void {
+    this.zosmfServerConfigComponent.save();
+    this.cancelUnsavedChangesDialog();
+    this.activeMenuItem = this.requestedMenuItem;
+  }
+
+  abandonChanges(): void {
+    this.zosmfServerConfigComponent.cancel();
+    this.cancelUnsavedChangesDialog();
+    this.activeMenuItem = this.requestedMenuItem;
+  }
+
+  exit(): void {
+    this.resolveClose();
+  }
+
+  cancelCloseDialog(): void {
+    this.isOnCloseDialogVisible = false;
+    this.globalVeilService.hideVeil();
+    this.rejectClose();
+  }
+
+  cancelUnsavedChangesDialog(): void {
+    this.isUnsavedChangesDialogVisible = false;
+    this.globalVeilService.hideVeil();
   }
 
   onStepSelectedAction(stepAction: WorkflowStepAction): void {
@@ -141,12 +187,29 @@ export class WorkflowAppComponent implements AfterContentInit {
   }
 
   showMyTasks(): void {
-    this.activeMenuItem = 'My Tasks';
+    if (!this.serverConfigNotSaved('My Tasks'))
+    { 
+      this.activeMenuItem = 'My Tasks'; 
+    }
   }
 
   showWorkflows(): void {
-    this.activeMenuItem = 'Workflows';
-    this.workflowListComponent.update();
+    if (!this.serverConfigNotSaved('Workflows'))
+    {
+      this.activeMenuItem = 'Workflows';
+      this.workflowListComponent.update();
+    }
+  }
+
+  serverConfigNotSaved(requestedMenuItem: WorkflowView): boolean {
+    if (this.activeMenuItem == 'Configuration' && this.zosmfServerConfigComponent.unsavedChanges() == true)
+      { 
+        this.requestedMenuItem = requestedMenuItem;
+        this.isUnsavedChangesDialogVisible = true;
+        this.globalVeilService.showVeil();
+        return true;
+      }
+    return false;
   }
 
   showConfiguration(): void {
@@ -155,8 +218,11 @@ export class WorkflowAppComponent implements AfterContentInit {
   }
 
   showWarnings(): void {
-    this.activeMenuItem = 'Warnings';
-    this.workflowWarningsComponent.update();
+    if (!this.serverConfigNotSaved('Warnings'))
+    { 
+      this.activeMenuItem = 'Warnings';
+      this.workflowWarningsComponent.update();
+    }
   }
 
   showView(view: WorkflowView): void {

--- a/webClient/src/app/zosmf-server-config/zosmf-server-config.component.html
+++ b/webClient/src/app/zosmf-server-config/zosmf-server-config.component.html
@@ -50,7 +50,7 @@
   </div>
 </div>
 <zosmf-login #zosmflogin on-loggedIn="login()" on-canceled="loginCanceled()"></zosmf-login>
-<zlux-popup-manager>
+<zlux-popup-manager *ngIf="popupEnabled">
 </zlux-popup-manager>
 <!--
   This program and the accompanying materials are

--- a/webClient/src/app/zosmf-server-config/zosmf-server-config.component.ts
+++ b/webClient/src/app/zosmf-server-config/zosmf-server-config.component.ts
@@ -52,6 +52,7 @@ export class ZosmfServerConfigComponent {
   zosmfServers: QueryList<ZosmfServerComponent>;
   @Output() configured = new EventEmitter<ZosmfServer>();
   private zosmfServerCandidate: ZosmfServer;
+  private popupEnabled: boolean;
 
   constructor(
     private configService: ZosmfServerConfigService,
@@ -59,6 +60,7 @@ export class ZosmfServerConfigComponent {
     private popupManager: ZluxPopupManagerService,
   ) {
     const config = this.configService.getCachedConfig();
+    this.popupEnabled = true;
     popupManager.setLogger(logger);
     if (config) {
       this.config = config;
@@ -76,6 +78,23 @@ export class ZosmfServerConfigComponent {
 
   save(): void {
     this.configService.saveConfig(this.config);
+  }
+
+  unsavedChanges(): boolean {
+    if (this.configService.getLocalConfig() == null)
+    { return true; }
+    else if (this.configService.getLocalConfig().zosmfServers.length != this.config.zosmfServers.length)
+      { return true; }
+    else if (this.configService.getLocalConfig().defaultZosmfServer.host != this.config.defaultZosmfServer.host ||
+        this.configService.getLocalConfig().defaultZosmfServer.port != this.config.defaultZosmfServer.port)
+      { return true; }
+    for (let check = this.config.zosmfServers.length; check--;)
+    {
+      if (this.config.zosmfServers[check].host != this.configService.getLocalConfig().zosmfServers[check].host ||
+      this.config.zosmfServers[check].port != this.configService.getLocalConfig().zosmfServers[check].port)
+      { return true; }
+    }
+    return false;
   }
 
   setDefault(item: ZosmfServer) {
@@ -115,6 +134,7 @@ export class ZosmfServerConfigComponent {
         const options = {
           blocking: true
         };
+          this.popupEnabled = true;
           this.popupManager.reportError(ZluxErrorSeverity.ERROR, errorTitle.toString()+": "+err.status.toString(), errorMessage+"\n"+err.toString(), options);  
         });
   }
@@ -142,6 +162,10 @@ export class ZosmfServerConfigComponent {
 
   loginCanceled(): void {
     this.zosmfLoginComponent.setZosmfServer(this.config.defaultZosmfServer);
+  }
+
+  togglePopup(toggle: boolean): void {
+    this.popupEnabled = toggle;
   }
 
 


### PR DESCRIPTION
This adds an unsaved changes prompt that is activated when there have been edits made to the Configurations page, and the user tries to move away from the page or close the plugin.

This PR now uses the enhanced zlux-popup-window that accepts a popupStyle parameter, allowing it to look OK UI-wise.

Signed-off-by: Leanid Astrakou <lastrakou@rocketsoftware.com>