### PR TITLE
ltpa cookie security fixes

### DIFF
--- a/lib/zosmf-service.js
+++ b/lib/zosmf-service.js
@@ -80,10 +80,11 @@ ZosmfServiceHandler.prototype.makeZosmfRequestOptions = function (request, zosmf
   return zosmfRequestOptions;
 };
 
-ZosmfServiceHandler.prototype.makeZosmfRequest = function (request, response, zosmfHost, zosmfPort, requestBody, serviceSubUrl) {
+ZosmfServiceHandler.prototype.makeZosmfRequest = function (request, response, zosmfHost,
+                                                           zosmfPort, requestBody, serviceSubUrl) {
   const zosmfRequestOptions = this.makeZosmfRequestOptions(request, zosmfHost, zosmfPort, serviceSubUrl);
   const zosmfRequest = https.request(zosmfRequestOptions, (zosmfResponse) => {
-    this.transformZosmfResponse(zosmfResponse);
+    this.transformZosmfResponse(zosmfResponse,!(request.protocol == 'http'));
     response.writeHead(zosmfResponse.statusCode, zosmfResponse.statusMessage, zosmfResponse.headers);
     zosmfResponse.pipe(response);
   }).on('error', (err) => {
@@ -95,8 +96,8 @@ ZosmfServiceHandler.prototype.makeZosmfRequest = function (request, response, zo
   request.pipe(zosmfRequest);
 };
 
-ZosmfServiceHandler.prototype.transformZosmfResponse = function (zosmfResponse) {
-  this.transformZosmfResponseCookies(zosmfResponse);
+ZosmfServiceHandler.prototype.transformZosmfResponse = function (zosmfResponse, secureConnection) {
+  this.transformZosmfResponseCookies(zosmfResponse, secureConnection);
   this.transformZosmfResponseStatusCode(zosmfResponse);
 };
 
@@ -106,12 +107,13 @@ ZosmfServiceHandler.prototype.transformZosmfResponseStatusCode = function (zosmf
   }
 };
 
-ZosmfServiceHandler.prototype.transformZosmfResponseCookies = function (zosmfResponse) {
+ZosmfServiceHandler.prototype.transformZosmfResponseCookies = function (zosmfResponse, secureConnection) {
     let zosmfResponseCookies = zosmfResponse.headers['set-cookie'];
     if (Array.isArray(zosmfResponseCookies)) {
       zosmfResponseCookies = zosmfResponseCookies.map(cookie => cookie.replace(/Domain\=[^;]+;/, ''));
-      zosmfResponseCookies = zosmfResponseCookies.map(cookie => cookie.replace(/Secure;/, ''));
-      zosmfResponseCookies = zosmfResponseCookies.map(cookie => cookie.replace(/HttpOnly/, ''));
+      if (!secureConnection) {
+        zosmfResponseCookies = zosmfResponseCookies.map(cookie => cookie.replace(/Secure;/, ''));
+      }
       zosmfResponse.headers['set-cookie'] = zosmfResponseCookies;
     }
 };


### PR DESCRIPTION
Make ltpa cookies httponly, and secure when can be secure (https)
Resolves https://github.com/zowe/zlux-workflow/issues/25
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>