### PR TITLE
Change from sending text to sending JSON

### DIFF
--- a/webClient/src/app/shared/zosmf-server-config.service.ts
+++ b/webClient/src/app/shared/zosmf-server-config.service.ts
@@ -82,7 +82,7 @@ export class ZosmfServerConfigService {
     };
     this.cachedConfig = serverConfig;
     localStorage.setItem(this.storageKey, JSON.stringify(serverConfig));
-    return this.http.put(this.uri, JSON.stringify(configWithMatadata)).toPromise()
+    return this.http.put(this.uri, configWithMatadata).toPromise()
     .catch(err => {
       
     let errorTitle: string = "Error";


### PR DESCRIPTION
Because the config service deals with JSON, so no need to transform it.
Signed-off-by: 1000TurquoisePogs <sgrady@rocketsoftware.com>